### PR TITLE
GitHub Actions workflow automates the process of generating patch files and SHA-256 hashes

### DIFF
--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -1,0 +1,76 @@
+name: Update metadata 
+
+on:
+  push:
+
+  workflow_dispatch:
+
+jobs:
+  update-patches:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Patch file for .vbs files
+        run: |
+            for dir in */; do
+              if [[ -d "$dir" ]]; then
+                echo "Entering directory: $dir"
+                cd "$dir"
+                shopt -s nullglob
+                for file in *.original; do
+                  basename="${file%.*.*}"
+                  for file2 in "$basename.vbs"; do
+                    diff -w -U0 --label="$file" "$file" --label="$file2" "$file2" > "$file2.patch" || true
+                  done
+                done
+                shopt -u nullglob
+                cd - > /dev/null 2>&1
+              fi
+            done
+
+      - name: Generate Hashes for .vbs files
+        run: |
+          data='[]'
+          baseUrl="https://raw.githubusercontent.com/${{ github.repository }}/refs/heads/master/"
+
+          for dir in */; do
+            if [[ -d "$dir" ]]; then
+              echo "Entering directory: $dir"
+              cd "$dir"
+              shopt -s nullglob
+              for file in *.vbs; do
+                for file2 in "$file.original"; do
+                  hash=$(sha256sum "$file" | awk '{print $1}')
+                  hash2=$(sha256sum "$file2" | awk '{print $1}')
+                  new_item="{\"file\": \"$file2\", \"sha256\": \"$hash2\", \"url\": \"$baseUrl$dir$file2\", \"patched\": { \"file\": \"$file\", \"sha256\": \"$hash\", \"url\": \"$baseUrl$dir$file\"}  }"
+                  echo $new_item
+                  data=$(jq --argjson new "$new_item" '. + [$new]' <<< "$data")
+                done
+              done
+              cd - > /dev/null 2>&1
+              shopt -u nullglob
+            fi
+          done
+          echo "$data" > hashes.json
+
+      - name: Upload Hashes Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hashes
+          path: hashes.json
+
+      - if: github.repository == 'jsm174/vpx-standalone-scripts' && github.ref == 'refs/heads/master'
+        name: Commit and Push Changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "meta: regenerate hashes and vbs diffs"
+          git push
+          

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vpx-standalone-scripts
 Table patches for VPX Standalone
 
-[Visual Pinball](https://github.com/vpinball/vpinball) Standalone is using the [vbscript engine](https://gitlab.winehq.org/wine/wine/-/tree/master/dlls/vbscript?ref_type=heads) from [Wine](https://www.winehq.org/) and there are some slight [incompatibilities](https://github.com/vpinball/vpinball/blob/10.8.1/standalone/README.md#background). Luckily only a few tables require modifications.
+[Visual Pinball](https://github.com/vpinball/vpinball) Standalone is using the [vbscript engine](https://gitlab.winehq.org/wine/wine/-/tree/master/dlls/vbscript?ref_type=heads) from [Wine](https://www.winehq.org/) and there are some slight [incompatibilities](https://github.com/vpinball/vpinball/blob/master/standalone/README.md#background). Luckily only a few tables require modifications.
 
 This repository contains the original script, patch, and fixed script for tables that do not run properly by default.
 
@@ -11,11 +11,34 @@ Just find the related file with `.vbs` extention in this repository. It should h
 
 ## Creating a patch
 
-1. Start by extracting the script
-  ```shell
-  VPinballX_GL -extractvbs [tablename.vpx]
-  ```
-2. Apply the patch, put it in this repository and run `./generate.sh`
-3. Create a PR with the changes
+1. Start by extracting the script:
 
-*You can also use [vpxtool](https://github.com/francisdb/vpxtool) to extract, apply some automatic fixes and generate patch files.*
+```shell
+VPinballX_GL -extractvbs [table.vpx]
+```
+
+```shell
+VPinballX_BGFX -extractvbs [tablename.vpx]
+```
+
+```shell
+/Applications/VPinballX_GL.app/Contents/MacOS/VPinballX_GL -extractvbs [table.vpx]
+```
+
+```shell
+/Applications/VPinballX_BGFX.app/Contents/MacOS/VPinballX_BGFX -extractvbs [table.vpx]
+```
+
+```shell
+vpxtool extractvbs [table.vpx]
+```
+
+2. Apply the patch, put it in this repository and run `./generate.sh`
+
+3. Create a PR with the changes. 
+
+> [!NOTE]
+> You do not need to submit `[table.vbs.patch]` in your PR as the CI will generate these automatically.
+
+> [!TIP]
+> You can also use [vpxtool](https://github.com/francisdb/vpxtool) to extract, apply some automatic fixes and generate patch files.


### PR DESCRIPTION
The PR encompasses adding a new GitHub workflow for automating the generation of diffs (.patch) and hashes of both the original and patched version of the vpx scripts.  The workflow is triggered on every __push__ to the repo.  

The hash generation adds a hashes.json to root of the repo and also generates a hashes.json artifact.   The file format looks like this:

```
[
  {
    "file": "Power Play (Bally 1977).vbs.original",
    "sha256": "ef9b7f6c10256d74ce8928c056ff138807a7859c8a27b70e9e2f70f57fb61dfd",
    "url": "https://raw.githubusercontent.com/superhac/vpx-standalone-scripts/refs/heads/master/1256692067_PowerPlay(Bally1977)2.1/Power Play (Bally 1977).vbs.original",
    "patched": {
      "file": "Power Play (Bally 1977).vbs",
      "sha256": "7fb40259669996f5bc14e64306aa9609e669a71bb459dee0a65f8bd8e9dd4d00",
      "url": "https://raw.githubusercontent.com/superhac/vpx-standalone-scripts/refs/heads/master/1256692067_PowerPlay(Bally1977)2.1/Power Play (Bally 1977).vbs"
    }
  },
  {
    "file": "1342729923_RollerCoasterTycoon(Stern2002)1.3.vbs.original",
    "sha256": "70b7c460269a96a460bc81a93f6c372141c663fa99893d3e4c4362e0c479e105",
    "url": "https://raw.githubusercontent.com/superhac/vpx-standalone-scripts/refs/heads/master/1342729923_RollerCoasterTycoon(Stern2002)1.3/1342729923_RollerCoasterTycoon(Stern2002)1.3.vbs.original",
    "patched": {
      "file": "1342729923_RollerCoasterTycoon(Stern2002)1.3.vbs",
      "sha256": "33a526f1cb240ef77fdbd821ad4f7c549fb95b5f55c7055cdd1f9e1492a6fb0e",
      "url": "https://raw.githubusercontent.com/superhac/vpx-standalone-scripts/refs/heads/master/1342729923_RollerCoasterTycoon(Stern2002)1.3/1342729923_RollerCoasterTycoon(Stern2002)1.3.vbs"
    }
  },
```

## Solves
1. You no longer have to compute the .patch file locally.  You just push the original and patched vbs script to the repo and it will generate the .patch file. 
2. The hashes are useful for automated downloading the right patch for the right version of that table.  You no longer have to rely on problematic and unstandardized filenames.  

## Important
The hashes that are generated are based the way they are stored in GitHub.  Currently they are stored with MS-DOS style line endings, but when any of the files are transferred out of GitHub, in any other way then using git, for instance via wget the raw link,  they will be converted to utf-8.    

So in any case outside of git you need make sure when comparing hashes that both files have the MS-DOS style line endings or they will never match.  