### PR TITLE
ci: use default unified diffs with 3 lines of context

### DIFF
--- a/.github/workflows/update_metadata.yml
+++ b/.github/workflows/update_metadata.yml
@@ -26,7 +26,7 @@ jobs:
                 for file in *.original; do
                   basename="${file%.*.*}"
                   for file2 in "$basename.vbs"; do
-                    diff -w -U0 --label="$file" "$file" --label="$file2" "$file2" > "$file2.patch" || true
+                    diff -w -u --label="$file" "$file" --label="$file2" "$file2" > "$file2.patch" || true
                   done
                 done
                 shopt -u nullglob


### PR DESCRIPTION
#362 removed the context for all patches which made it harder to get an idea of what the patch is doing